### PR TITLE
Don't send emails about closed projects; Also move some repeated logi…

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -47,7 +47,7 @@ class Plugin extends Base
 
 	public function getPluginVersion() 
 	{ 	 
-		return '1.2.1'; 
+		return '1.2.2'; 
 	}
 
 	public function getPluginDescription() 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Donate to help keep this project maintained.
 - It's the least you can do for all the work put into it!
 
 # Auto Email Extended Actions
-This plugin will add 4 new automatic actions to Kanboard.
+This plugin will add 5 new automatic actions to Kanboard.
 
 *1.) Send task by email to assignee*
 


### PR DESCRIPTION
…c into its own method.

Hello again! I've been enjoying your plugin since our last exchange, but recently have noticed it sends emails about projects that have been closed.

This pull request is a patch that prevents the plugin from sending emails about closed projects. It also takes some repeated logic, and moves it into a dedicated method.

Hope you like it!