### PR TITLE
Added Translation "Deutsch (du)"

### DIFF
--- a/Locale/de_DE_du/translations.php
+++ b/Locale/de_DE_du/translations.php
@@ -1,0 +1,10 @@
+<?php
+return array(
+  'Email subject' => 'E-Mail Betreff',
+  'Duration in days' => 'Laufzeit in Tagen',
+  'Send a task by email to creator' => 'Sende eine Aufgabe per E-Mail an den Ersteller',
+  'Send a task by email to assignee' => 'Sende eine Aufgabe per E-Mail an den Zuständigen',
+  'Send email notification of impending due date' => 'Sende eine E-Mail Benachrichtigung wenn es fällig wird',
+  'Send email notification of impending subtask due date' => 'Sende eine E-Mail Benachrichtigung wenn Teilaufgabe fällig wird',
+  'Include Task Title and ID in subject line?' => 'Ergänze Titel und ID der Aufgabe in die E-Mail Betreffzeile',
+);


### PR DESCRIPTION
With [this approved pull-request](https://github.com/kanboard/kanboard/pull/4767) the German translation will now come in 2 flavours.
This PR adds the new German flavour "Deutsch (du)" to the SendEmailCreator-plugin