### PR TITLE
Add Dutch translations for email-related phrases

### DIFF
--- a/Locale/nl_NL/translations.php
+++ b/Locale/nl_NL/translations.php
@@ -1,0 +1,11 @@
+<?php
+
+return array(
+  'Email subject' => 'E-Mail onderwerp',
+  'Duration in days' => 'Looptijd in dagen',
+  'Send a task by email to creator' => 'Een taak per e-mail verzenden naar de maker',
+  'Send a task by email to assignee' => 'Een taak per e-mail verzenden naar de verantwoordelijke',
+  'Send email notification of impending due date' => 'Een e-mailbericht verzenden over de naderende vervaldatum',
+  'Send email notification of impending subtask due date' => 'Een e-mailbericht verzenden over een naderende vervaldatum voor een subtaak',
+  'Include Task Title and ID in subject line?' => 'Taaktitel en ID in onderwerpregel opnemen?',
+);


### PR DESCRIPTION
This commit adds Dutch translations for various email-related phrases in the application. Now, users who prefer to use the Dutch language will see these phrases translated correctly.